### PR TITLE
'candidate_fusion-genes_missing_mates.txt' deleted at 5849 but used at 7297

### DIFF
--- a/bin/fusioncatcher.py
+++ b/bin/fusioncatcher.py
@@ -5846,7 +5846,7 @@ if __name__ == "__main__":
 #        job.clean(outdir('reads_filtered_transcriptome_sorted-read.map'),temp_path=temp_flag)
         job.clean(outdir('original.fq.gz'),temp_path=temp_flag)
         job.clean(outdir('originala.fq.gz'),temp_path=temp_flag if options.skip_spotlight else 'no')
-        job.clean(outdir('candidate_fusion-genes_missing_mates.txt'),temp_path=temp_flag)
+        #job.clean(outdir('candidate_fusion-genes_missing_mates.txt'),temp_path=temp_flag)
         job.clean(outdir('candidate_fusion-genes_supporting_paired-reads.txt'),temp_path=temp_flag if options.skip_spotlight else 'no')
         #job.clean(outdir('candidate_fusion-genes_exon-exon.txt'))
 

--- a/bin/generate_exon-exon_junctions.py
+++ b/bin/generate_exon-exon_junctions.py
@@ -399,10 +399,10 @@ Length_of_the_exon-exon_juntion = 2 * (length_reads - overlap_read). The joint p
                             s1=sb[aa:ebe].upper()
                             s2=sa[eas-1:bb].upper()
                             seq=s1+s2
-                            
+
                             if ispoly(s1) or ispoly(s2):
                                 doit = False
-                                
+
                             idx=None # the sequence that are the same have the same index
 
                             doit=True
@@ -453,7 +453,10 @@ Length_of_the_exon-exon_juntion = 2 * (length_reads - overlap_read). The joint p
     if options.output_cut_filename:
         if sequences_cut:
             Bio.SeqIO.write(sequences_cut,handle_cut,"fasta")
+        handle_cut.flush()
         handle_cut.close()
+        if os.path.getsize(options.output_cut_filename) == 0:
+            file(options.output_cut_filename,"w").write(">empty\nACGTACGTACGTACGTA")
 
     if options.output_count_seq_filename:
         file(options.output_count_seq_filename,"w").write("%d" % (count_seq,))


### PR DESCRIPTION
At line 5849 in `fusioncatcher.py` the   `candidate_fusion-genes_missing_mates.txt` file is deleted but is used elsewhere at line 7297, then deleted anyways at 11775:

At line 5849:
```   
 job.clean(outdir('candidate_fusion-genes_missing_mates.txt'),temp_path=temp_flag)
```
Line 7297:
```
job.add('--input_candidate_fusions_missing_mates',outdir('candidate_fusion-genes_missing_mates.txt'),kind='input',temp_path=temp_flag)
```
Line 11775:
```

    to_delete = [
        outdir('reads_mapped-exon-exon-fusion-genes_sorted-ref.map'),
```
...
```
        outdir('candidate_fusion-genes_missing_mates.txt'),
```
...