### PR TITLE
Hardcode useast.ensembl.org to avoid redirections refs #100

### DIFF
--- a/bin/fusioncatcher-build.py
+++ b/bin/fusioncatcher-build.py
@@ -189,7 +189,7 @@ if __name__ == '__main__':
                       action = "store",
                       type = "string",
                       dest = "web_ensembl",
-                      default = 'www.ensembl.org',
+                      default = 'useast.ensembl.org',
                       help = "Ensembl database web site from where the data is downloaded. "+
                              " e.g. 'www.ensembl.org', 'uswest.ensembl.org', "+
                              "'useast.ensembl.org', 'asia.ensembl.org', etc. "+

--- a/bin/get_biotypes.py
+++ b/bin/get_biotypes.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org", # feb2014.archive.ensembl.org => Ensembl release 75
+                      default = "useast.ensembl.org", # feb2014.archive.ensembl.org => Ensembl release 75
                       help="""The Ensembl server from where the genes biotypes are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     parser.add_option("--server-path",

--- a/bin/get_exons_positions.py
+++ b/bin/get_exons_positions.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org",
+                      default = "useast.ensembl.org",
                       help="""The Ensembl server from where the exons positions are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     (options,args) = parser.parse_args()

--- a/bin/get_genes_descriptions.py
+++ b/bin/get_genes_descriptions.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org",
+                      default = "useast.ensembl.org",
                       help="""The Ensembl server from where the genes positions are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     (options,args) = parser.parse_args()

--- a/bin/get_hla2.py
+++ b/bin/get_hla2.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org",
+                      default = "useast.ensembl.org",
                       help="""The Ensembl server from where the HLA sequences are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     (options,args) = parser.parse_args()

--- a/bin/get_mtrna.py
+++ b/bin/get_mtrna.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org",
+                      default = "useast.ensembl.org",
                       help="""The Ensembl server from where the rRNA sequences are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     (options,args) = parser.parse_args()

--- a/bin/get_paralogs.py
+++ b/bin/get_paralogs.py
@@ -90,7 +90,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org",
+                      default = "useast.ensembl.org",
                       help="""The Ensembl server from where the paralog genes are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     (options,args) = parser.parse_args()

--- a/bin/get_refseq_ensembl.py
+++ b/bin/get_refseq_ensembl.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org",
+                      default = "useast.ensembl.org",
                       help="""The Ensembl server from where the genes positions are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     (options,args) = parser.parse_args()

--- a/bin/get_rrna.py
+++ b/bin/get_rrna.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org",
+                      default = "useast.ensembl.org",
                       help="""The Ensembl server from where the rRNA sequences are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     (options,args) = parser.parse_args()

--- a/bin/get_trna.py
+++ b/bin/get_trna.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
                       action="store",
                       type="string",
                       dest="server",
-                      default = "www.ensembl.org",
+                      default = "useast.ensembl.org",
                       help="""The Ensembl server from where the tRNA sequences are downloaded, e.g. 'www.ensembl.org', 'uswest.ensembl.org', 'useast.ensembl.org', 'asia.ensembl.org', etc. Default is '%default'.""")
 
     (options,args) = parser.parse_args()


### PR DESCRIPTION
Hardcode an individual mirror `useast.ensembl.org` to avoid redirection problems discussed in #100 