### PR TITLE
introduce developer mode for using unofficial versions, refs #102

### DIFF
--- a/etc/configuration.cfg
+++ b/etc/configuration.cfg
@@ -1,3 +1,5 @@
+# NOTE this file is overwritten by `bootstrap.py` to produce correct absolute
+# paths under the FusionCatcher directory.
 [paths]
 python = /usr/bin/
 #
@@ -38,7 +40,7 @@ threads = 0
 aligners = blat,star
 
 [versions]
-fusioncatcher = 1.00
+fusioncatcher = 1.10
 
 
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -10,7 +10,7 @@ fi
 
 rm -rf "test_fusioncatcher"
 
-"$fbin/../bin/fusioncatcher.py" --input "$fbin/" --output "test_fusioncatcher" 
+"$fbin/../bin/fusioncatcher.py" --min-memory 2000 --input "$fbin/" --output "test_fusioncatcher"
 
 if [ -f "$fbin/summary_candidate_fusions.txt" ]; then
     LC_ALL=C sort "$fbin/summary_candidate_fusions.txt" | grep "*" > "test_fusioncatcher/summary_candidate_fusions_a.txt"


### PR DESCRIPTION
* when environment variable `FUSIONCATCHER_DEV_MODE` is set avoids
  downloading the official version in `bootstrap` and uses the local
  copy.
* avoids overwriting contents of local repo as part of `bootstrap`.
* does not crash for build and data version mismatches.
* fix STAR version to the one currently downloaded by `bootstrap.py -t`
  to avoid crash.
* match current version of fusioncatcher in /etc/configuration.cfg
* add a --min-memory option to fusioncatcher defaulting to the current
  minimum of 23000 MB so that installation/tests can be run on smaller
  machines.
* use --min-memory 2000 in test/tests.sh since the input files are very
  small.