### PR TITLE
Changed how BBmap version is checked

### DIFF
--- a/bin/fusioncatcher.py
+++ b/bin/fusioncatcher.py
@@ -2326,9 +2326,9 @@ if __name__ == "__main__":
         "is in the corresponding PATH!"))
 
     # check version
-    os.system(_BP_+"bbmap.sh --version 2>&1 |head -2 |tail -1 > '%s'" % (outdir('bbmap_version.txt'),))
+    os.system(_BP_+"bbversion.sh > '%s'" % (outdir('bbmap_version.txt'),))
     last_line = file(outdir('bbmap_version.txt'),'r').readline().lower().rstrip("\r\n")
-    correct_version = ('bbmap version 38.44',)
+    correct_version = ('38.44',)
     if last_line not in correct_version:
         job.close()
         os.system("which bbmap.sh > '%s'" % (outdir('bbmap_path.txt'),))


### PR DESCRIPTION
Changed to using BBversion.sh for checking the version of BBmap.sh. 

The reason was that I was having problems running fusioncatcher on a cluster using SGEs qsub. I believe the problem lies in how STDOUT and STDERR works when submitting through qsub, making it problematic in redirecting both STDOUT and STDERR to the bbmap_version.txt file.

Instead using bbversion.sh alleviates this issue.